### PR TITLE
_oasis SourceRepository at GitHub

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -108,6 +108,7 @@ Document "api-ounit"
   XOCamlbuildPath:      src/
 
 SourceRepository head
-  Type: darcs
-  Location: http://darcs.ocamlcore.org/repos/ounit
-  Browser: http://darcs.ocamlcore.org/cgi-bin/darcsweb.cgi?r=ounit;a=summary
+  Type: git
+  Location: https://github.com/gildor478/ounit.git
+  Branch: master
+  Browser: https://github.com/gildor478/ounit


### PR DESCRIPTION
This PR is me asking the question "Is this how it's done?"

- In the _oasis file: Change the `SourceRepository` to `git` as seen at https://ocaml.org/learn/tutorials/setting_up_with_oasis.html

(There were one more reference to darcs in the repo, in the ardivink.lua file, but it seems to relate to a now-defunct CI environment.)