### PR TITLE
Fix #1744: Not_found exception with -output-junit-file

### DIFF
--- a/src/oUnitUtils.ml
+++ b/src/oUnitUtils.ml
@@ -211,7 +211,11 @@ let failwithf fmt =
 
 let opt f = function Some v -> f v | None -> ()
 
-let fqdn () = (Unix.gethostbyname (Unix.gethostname ())).Unix.h_name
+let fqdn () =
+    try
+        (Unix.gethostbyname (Unix.gethostname ())).Unix.h_name
+    with
+        Not_found -> "localhost"
 
 let shardf = Printf.sprintf "%s#%02d" (Unix.gethostname ())
 


### PR DESCRIPTION
This resolves: https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1744&group_id=162&atid=730

The root cause is that [`OUnitLoggerJUnit` tries to resolve the hostname of the current machine](https://github.com/gildor478/ounit/blob/6c660fbb9627de37749be8bd26d6c0ca263859cb/src/oUnitLoggerJUnit.ml#L66-L75) (using the [fqdn helper](https://github.com/gildor478/ounit/blob/6c660fbb9627de37749be8bd26d6c0ca263859cb/src/oUnitUtils.ml#L214)):

```language:ocaml
let fqdn () = (Unix.gethostbyname (Unix.gethostname ())).Unix.h_name
```

If the [docs are to be believed](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#VALgethostname) `Unix.gethostbyname` only looks in `/etc/hosts` to get the hostname for `Unix.gethostname`. A `Unix.gethostname` alone probably would be enough, because the only way the second function would do anything is if you have multiple names for `127.0.0.1` in `/etc/hosts` and your hostname is not the first in that list of names. Of course, the hostname may not be in `/etc/hosts` on all machines, so this may fail. And sure enough the test for the HTML and JUnit loggers fails for me as a result.

The fix is to just wrap it in a try and return `"localhost"` if the lookup fails (which [according to this sample JUnit file is acceptable](https://stackoverflow.com/a/9410271/568785)).