### PR TITLE
Handle infinity and NaN in cmp_float (fixes #1381).

### DIFF
--- a/src/oUnit2.mli
+++ b/src/oUnit2.mli
@@ -144,6 +144,9 @@ val todo : string -> unit
 
 (** Compare floats up to a given relative error.
 
+    In keeping with standard floating point semantics, NaN is not equal to
+    anything: [cmp_float nan nan = false].
+
     @param epsilon if the difference is smaller [epsilon] values are equal
   *)
 val cmp_float : ?epsilon:float -> float -> float -> bool

--- a/src/oUnitUtils.ml
+++ b/src/oUnitUtils.ml
@@ -128,8 +128,12 @@ let extract_backtrace_position str =
       (split_lines str)
 
 let cmp_float ?(epsilon = 0.00001) a b =
-  abs_float (a -. b) <= epsilon *. (abs_float a) ||
-    abs_float (a -. b) <= epsilon *. (abs_float b)
+  match classify_float a, classify_float b with
+  | FP_infinite, FP_infinite -> a = b
+  | FP_infinite, _ | _, FP_infinite | FP_nan, _ | _, FP_nan -> false
+  | _, _ ->
+    abs_float (a -. b) <= epsilon *. (abs_float a) ||
+      abs_float (a -. b) <= epsilon *. (abs_float b)
 
 let buff_format_printf f =
   let buff = Buffer.create 13 in

--- a/test/testOUnit1.ml
+++ b/test/testOUnit1.ml
@@ -111,7 +111,17 @@ let test_cmp_float _ =
   assert_equal ~cmp: cmp_float 0.0001 0.0001;
   assert_equal ~cmp: (cmp_float ~epsilon: 0.001) 1.0001 1.00001;
   assert_raises (OUnitTest.OUnit_failure "not equal")
-      (fun _ -> assert_equal ~cmp: cmp_float 100.0001 101.001)
+    (fun _ -> assert_equal ~cmp: cmp_float 100.0001 101.001);
+  assert_equal ~cmp:cmp_float infinity infinity;
+  assert_equal ~cmp:cmp_float neg_infinity neg_infinity;
+  assert_raises ~msg:"inf <> 0" (OUnitTest.OUnit_failure "not equal")
+    (fun _ -> assert_equal ~cmp: cmp_float infinity 0.0);
+  assert_raises ~msg:"inf <> -inf" (OUnitTest.OUnit_failure "not equal")
+    (fun _ -> assert_equal ~cmp: cmp_float infinity neg_infinity);
+  assert_raises ~msg:"nan <> 0" (OUnitTest.OUnit_failure "not equal")
+    (fun _ -> assert_equal ~cmp: cmp_float nan 0.);
+  assert_raises ~msg:"nan <> nan" (OUnitTest.OUnit_failure "not equal")
+    (fun _ -> assert_equal ~cmp: cmp_float nan nan)
 
 let test_assert_string _ =
   assert_string "";


### PR DESCRIPTION
Add special-case handling for infinities and NaN to cmp_float.
In particular, the following rules are used to compare x and y:

- If x is an infinity, cmp_float x y = true iff x = y (i.e., y is
  the same kind of infinity)
- If x or y is a NaN, cmp_float x y = false.
- Otherwise, cmp_float x y = true iff |x - y| < epsilon * max(|x|,|y|)