### PR TITLE
try to trigger error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - PACKAGE=ounit OUNIT_CI=true PINS="ounit:. ounit-lwt:."
+    - POST_INSTALL_HOOK="opam install -t re"
 matrix:
   include:
     - apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   EXTRA_DEPS: dune
   OUNIT_CI: true
   PACKAGE: ounit
+  POST_INSTALL_HOOK: "opam install -t re"
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))


### PR DESCRIPTION
just a test to trigger the error described at #8
The handling of case sensitive file handling however depends on the Windows version and its settings (see e.g. https://cygwin.com/cygwin-ug-net/using-specialnames.html )
It might not be possible to reproduce the error, if appveyor is configured properly for unix compatibility.
