### PR TITLE
add list of `advanced` and `thread` modules to generated docs

### DIFF
--- a/src/lib/ounit2/index.mld
+++ b/src/lib/ounit2/index.mld
@@ -181,6 +181,17 @@ let _ =
 ;;
 ]}
 
+{3 OUnit2.Advanced}
+
+More modules are available in [ounit2.advanced]:
+{!modules: OUnitAssert OUnitBracket OUnitCache OUnitCheckEnv OUnitChooser OUnitConf OUnitCore OUnitDiff OUnitLogger OUnitLoggerCI OUnitLoggerHTML OUnitLoggerJUnit OUnitLoggerStd OUnitPlugin OUnitPropList OUnitResultSummary OUnitRunner OUnitRunnerProcesses OUnitShared OUnitState OUnitTest OUnitTestData OUnitUtils}
+
+{3 OUnit.Threads}
+
+Threading-related utilities.
+
+{!modules: OUnitThreads}
+
 {3 Effective OUnit}
 
 This section has general tips about unit testing and OUnit. It is the


### PR DESCRIPTION
see #12


edit: it's still lacking explanations about all the advanced modules, I think. I'd love to have an easy way to setup `run_test_tt_main` with a custom backend/logger or a colorful output or something, and right now the biggest impediment is that it's hard to find docs on that. :)