### PR TITLE
Update the backtrace parser for OCaml 4.11.0

### DIFF
--- a/src/lib/ounit2/advanced/oUnitUtils.ml
+++ b/src/lib/ounit2/advanced/oUnitUtils.ml
@@ -114,7 +114,7 @@ let extract_backtrace_position str =
               None
             else
               try
-                Scanf.sscanf eol "file \"%s@\", line %d, characters %d-%d"
+                Scanf.sscanf eol "%_s@\"%s@\", line %d, characters %d-%d"
                   (fun fn line _ _ -> Some (fn, line))
               with Scanf.Scan_failure _ ->
                 None


### PR DESCRIPTION
In OCaml 4.11, the backtrace has been updated to add function names whenever it is possible. For instance, in 4.11, a backtrace may look like

> Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26

compared to

> Called from file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26

in previous versions.

This change unfortunately breaks ounit backtrace parser.

This small PR proposes to update the parser to keep up with the improved backtrace messages.
The new Scanf format string is too clever for its own good but it works on all OCaml versions.

Close #17 