### PR TITLE
Remove dependency on `base-bytes`

### DIFF
--- a/ounit2.opam
+++ b/ounit2.opam
@@ -9,7 +9,6 @@ license: "MIT"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.11.0"}
-  "base-bytes"
   "base-unix"
   "seq"
   "stdlib-shims"

--- a/src/lib/ounit2/advanced/dune
+++ b/src/lib/ounit2/advanced/dune
@@ -7,4 +7,4 @@
   (name oUnitAdvanced)
   (public_name ounit2.advanced)
   (wrapped false)
-  (libraries unix bytes seq stdlib-shims))
+  (libraries unix seq stdlib-shims))


### PR DESCRIPTION
The bytes library is part of the OCaml compiler since 4.02, no need to declare it as a library.

This decreases the dependency cone and avoids pulling in `ocamlfind` transitively, since it is not required for `bytes`.