### PR TITLE
Handle end of channel in `Seq` API

### DIFF
--- a/src/lib/ounit2/advanced/oUnitAssert.ml
+++ b/src/lib/ounit2/advanced/oUnitAssert.ml
@@ -50,9 +50,10 @@ let assert_bool msg b =
 let assert_string str =
   if not (str = "") then assert_failure str
 
-(* TODO: Use Seq.forever from OCaml >= 4.14 *)
-let rec seq_forever f () =
-  Seq.Cons (f(), seq_forever f)
+let rec seq_of_channel channel () =
+  match input_char channel with
+  | exception End_of_file -> Seq.Nil
+  | char -> Seq.Cons (char, seq_of_channel channel)
 
 let assert_equal ?ctxt ?(cmp = ( = )) ?printer ?pp_diff ?msg expected actual =
   let get_error_string () =
@@ -316,7 +317,7 @@ let assert_command
            begin
              let chn = open_in fn_out in
                try
-                 foutput (seq_forever (fun () -> input_char chn))
+                 foutput (seq_of_channel chn)
                with e ->
                  close_in chn;
                  raise e


### PR DESCRIPTION
In #92 @kit-ty-kate added support for the `Seq` API instead of the `Stream` API to be compatible with OCaml 5, which is very convenient, as we are approaching a release soon

While attempting to port the `gettext` unit tests which use `assert_command` I ran into the issue that migrating the tests to the `Seq` API was simple but they were always failing with an `End_of_file` exception.

Upon further inspection I realized the issue must be in ounit, and indeed: the previous code used `Stream.of_channel` which presumably handled `End_of_file` while the new `Seq` API would build an infinite `Seq`, attempting to read from the end of a channel, even if it was already at the end.

This changes the code to implement a functionality similar to `Stream.of_channel`.

Attempting to run the `gettext` unit tests succeeds without issues with this patch.